### PR TITLE
Convert "Content" field id from number to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -374,7 +374,7 @@ class WebTableInstance extends InstanceBase {
                 const option = {
                     type: 'textinput',
                     label: `Content ${label}`,
-                    id: i,
+                    id: `${i}`,
                     useVariables: true,
                     default: '',
                     isVisibleData: i,


### PR DESCRIPTION
Fixes issue #13

Typing anything into the "Content A/B/etc." field(s) of an action would cause a "tRPC error" to be thrown by main.js. Changing the field's `id` attribute from a number to a string makes this error go away and restores the module's functionality.